### PR TITLE
(MAINT) remove markdown requirement

### DIFF
--- a/beaker-google.gemspec
+++ b/beaker-google.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |s|
 
   # Documentation dependencies
   s.add_development_dependency 'yard'
-  s.add_development_dependency 'markdown'
   s.add_development_dependency 'thin'
 
   # Run time dependencies


### PR DESCRIPTION
There is a known issue where markdown requires activesupport, which
requires Ruby 2.5.0. This makes testing below that version fail & it
turns out we don't actually need markdown, so we've been removing the
requirement as these issues come up. Originally found in our repos in
https://github.com/puppetlabs/beaker-puppet/pull/124